### PR TITLE
#61 catch and report exception: parsing + http + eval javascript

### DIFF
--- a/src/main/java/uos/dev/restcli/HttpRequestFilesExecutor.kt
+++ b/src/main/java/uos/dev/restcli/HttpRequestFilesExecutor.kt
@@ -78,7 +78,7 @@ class HttpRequestFilesExecutor constructor(
                 scriptHandlerStartLine = -1
             )
             TestReportStore.addTestGroupReport("-", trace)
-            TestReportStore.addTestReport("Parsing",false, e.message,e.message)
+            TestReportStore.addTestReport("Parsing", false, e.message, e.message)
             return
         }
         var requestIndex = -1
@@ -131,7 +131,7 @@ class HttpRequestFilesExecutor constructor(
                 executeSingleRequest(executor, request)
             }.onFailure {
                 logger.error { t.red(it.message.orEmpty()) }
-                TestReportStore.addTestReport("-",false, it.message,it.message)
+                TestReportStore.addTestReport("-", false, it.message, it.message)
             }
 
         }
@@ -148,12 +148,12 @@ class HttpRequestFilesExecutor constructor(
                         jsClient.execute(script)
                     }.onFailure {
                         logger.error { t.red(it.message.orEmpty()) }
-                        TestReportStore.addTestReport("eval script",false, it.message,script)
+                        TestReportStore.addTestReport("eval script", false, it.message, script)
                     }
                 }
             }
             .onFailure {
-                TestReportStore.addTestReport("Http",false, it.message,it.message)
+                TestReportStore.addTestReport("Http", false, it.message, it.message)
                 val hasScriptHandler = request.scriptHandler != null
                 if (hasScriptHandler) {
                     logger.info(t.yellow("[SKIP TEST] Because: ") + it.message.orEmpty())

--- a/src/main/java/uos/dev/restcli/HttpRequestFilesExecutor.kt
+++ b/src/main/java/uos/dev/restcli/HttpRequestFilesExecutor.kt
@@ -73,6 +73,12 @@ class HttpRequestFilesExecutor constructor(
             parser.parse(httpFilePath)
         } catch (e: Exception) {
             logger.error(e) { "Can't parse $httpFilePath" }
+            val trace = TestGroupReport.Trace(
+                httpTestFilePath = httpFilePath,
+                scriptHandlerStartLine = -1
+            )
+            TestReportStore.addTestGroupReport("-", trace)
+            TestReportStore.addTestReport("Parsing",false, e.message,e.message)
             return
         }
         var requestIndex = -1
@@ -114,6 +120,7 @@ class HttpRequestFilesExecutor constructor(
                     environment,
                     jsGlobalEnv
                 )
+
                 val trace = TestGroupReport.Trace(
                     httpTestFilePath = httpFilePath,
                     scriptHandlerStartLine = request.scriptHandlerStartLine
@@ -124,7 +131,9 @@ class HttpRequestFilesExecutor constructor(
                 executeSingleRequest(executor, request)
             }.onFailure {
                 logger.error { t.red(it.message.orEmpty()) }
+                TestReportStore.addTestReport("-",false, it.message,it.message)
             }
+
         }
     }
 
@@ -135,10 +144,16 @@ class HttpRequestFilesExecutor constructor(
                 request.scriptHandler?.let { script ->
                     val testTitle = t.bold("TESTS:")
                     logger.info("\n$testTitle")
-                    jsClient.execute(script)
+                    runCatching {
+                        jsClient.execute(script)
+                    }.onFailure {
+                        logger.error { t.red(it.message.orEmpty()) }
+                        TestReportStore.addTestReport("eval script",false, it.message,script)
+                    }
                 }
             }
             .onFailure {
+                TestReportStore.addTestReport("Http",false, it.message,it.message)
                 val hasScriptHandler = request.scriptHandler != null
                 if (hasScriptHandler) {
                     logger.info(t.yellow("[SKIP TEST] Because: ") + it.message.orEmpty())

--- a/src/main/java/uos/dev/restcli/executor/OkhttpRequestExecutor.kt
+++ b/src/main/java/uos/dev/restcli/executor/OkhttpRequestExecutor.kt
@@ -64,7 +64,7 @@ class OkhttpRequestExecutor(
             val sslSocketFactory = sslContext.socketFactory
             this.sslSocketFactory(sslSocketFactory, trustAllCerts[0] as X509TrustManager)
         }
-        return this;
+        return this
     }
 
     private val okHttpClient: OkHttpClient = OkHttpClient.Builder()

--- a/src/test/java/uos/dev/restcli/E2ETest.kt
+++ b/src/test/java/uos/dev/restcli/E2ETest.kt
@@ -3,7 +3,7 @@ package uos.dev.restcli
 import com.google.common.truth.Truth.assertThat
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.CsvSource
-import org.junit.jupiter.params.provider.ValueSource
+import uos.dev.restcli.report.TestReportStore
 
 class E2ETest {
     /**
@@ -12,8 +12,8 @@ class E2ETest {
      * resource folder.
      */
     @ParameterizedTest
-    @ValueSource(
-        strings = [
+    @CsvSource(
+        value = [
             "get-requests.http",
             "post-requests.http",
             "requests-with-authorization.http",
@@ -79,7 +79,10 @@ class E2ETest {
 
         // When
         val exitCode = restCli.call()
+
         // Then
         assertThat(exitCode).isEqualTo(1)
+
+        assertThat(TestReportStore.testGroupReports.all { it.testReports.size > 0 }).isTrue()
     }
 }

--- a/src/test/resources/requests/requests-with-failing-tests.http
+++ b/src/test/resources/requests/requests-with-failing-tests.http
@@ -42,3 +42,10 @@ client.test("Headers option exists", function() {
 ### timeout after 3s (this request took 4s)
 GET https://httpbin.org/delay/4
 
+
+### javascript error
+GET https://httpbin.org/get
+
+> {%
+response.body.undified_field.hasOwnProperty("dummy")
+%}


### PR DESCRIPTION
I try to add a call to TestReportStore on each catch.
I add a test with a javascript error.