### PR TITLE
Add maven-publish plugin to allow distribution via jitpack.io

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,6 +11,16 @@ version = "1.7.4"
 repositories {
     mavenCentral()
 }
+java {
+    withSourcesJar()
+}
+publishing {
+    publications {
+        create<MavenPublication>("restcli") {
+            from(components["java"])
+        }
+    }
+}
 
 dependencies {
     implementation(kotlin("stdlib-jdk8"))

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     java
     kotlin("jvm") version "1.3.72"
     kotlin("kapt") version "1.3.72"
+    `maven-publish`
 }
 
 group = "uos.dev"


### PR DESCRIPTION
[jitpack](https://jitpack.io/) is a service (free to use for open-source projects) which simplifies the deployment of JVM-based Git projects. They will build your code and host JAR artifacts which then can be used like a usual Maven or Gradle dependency.

The only requirement is that you alter your `build.gradle` as seen in my PR by adding the `maven-publish` plug-in and telling it to create a JAR. 