### PR TITLE
throw IllegalArgumentException if there is no environmentName for selected name

### DIFF
--- a/src/main/java/uos/dev/restcli/EnvironmentLoader.kt
+++ b/src/main/java/uos/dev/restcli/EnvironmentLoader.kt
@@ -39,7 +39,8 @@ class EnvironmentLoader {
             return null
         }
         val config = JsonParser.parseReader(file.reader())
-        return config.asJsonObject.get(environmentName).asJsonObject
+        return config.asJsonObject.get(environmentName)?.asJsonObject
+            ?: throw IllegalArgumentException("Can't find selected environment for $environmentName")
     }
 
     private val JsonElement.asStringOrNull: String?

--- a/src/test/java/uos/dev/restcli/EnvironmentLoaderTest.kt
+++ b/src/test/java/uos/dev/restcli/EnvironmentLoaderTest.kt
@@ -3,6 +3,7 @@ package uos.dev.restcli
 import com.google.common.truth.Truth.assertThat
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import uos.dev.restcli.Resource.getResourcePath
 import uos.dev.restcli.configs.EnvironmentConfigs
 import uos.dev.restcli.configs.NoopConfigDecorator
@@ -29,6 +30,18 @@ class EnvironmentLoaderTest {
         ).forEach { entry ->
             assertThat(env.containsKey(entry.key)).isTrue()
             assertThat(env.getValue(entry.key)).isEqualTo(entry.value)
+        }
+    }
+
+    @Test
+    fun failed_to_load_http_client_no_environment() {
+        val environmentFilesDirectory = getResourcePath("/requests")
+        EnvironmentConfigs.changeDefaultDecorator(NoopConfigDecorator)
+        assertThrows<IllegalArgumentException> {
+            EnvironmentLoader().load(
+                environmentFilesDirectory,
+                "not_valid_environmentName"
+            )
         }
     }
 }


### PR DESCRIPTION
If user try to use restcli with invalid environmentName, user only can see NullPointerException. 

I tried to inform them with more specific error message.