### PR TITLE
Give users the the possibility to increase the default connection timeout (default 10s)

### DIFF
--- a/src/main/java/uos/dev/restcli/executor/OkhttpRequestExecutor.kt
+++ b/src/main/java/uos/dev/restcli/executor/OkhttpRequestExecutor.kt
@@ -69,6 +69,7 @@ class OkhttpRequestExecutor(
 
     override fun execute(request: Request): Response {
         val client = okHttpClient.newBuilder().followRedirects(request.isFollowRedirects)
+            .connectTimeout(requestTimeout, TimeUnit.MILLISECONDS)
             .callTimeout(requestTimeout, TimeUnit.MILLISECONDS).build()
         val builder = OkhttpRequest.Builder()
         val requestTarget = obtainRequestTarget(request)

--- a/src/main/java/uos/dev/restcli/executor/OkhttpRequestExecutor.kt
+++ b/src/main/java/uos/dev/restcli/executor/OkhttpRequestExecutor.kt
@@ -71,6 +71,7 @@ class OkhttpRequestExecutor(
         val client = okHttpClient.newBuilder().followRedirects(request.isFollowRedirects)
             .connectTimeout(requestTimeout, TimeUnit.MILLISECONDS)
             .readTimeout(requestTimeout, TimeUnit.MILLISECONDS)
+            .writeTimeout(requestTimeout, TimeUnit.MILLISECONDS)
             .callTimeout(requestTimeout, TimeUnit.MILLISECONDS).build()
         val builder = OkhttpRequest.Builder()
         val requestTarget = obtainRequestTarget(request)

--- a/src/main/java/uos/dev/restcli/executor/OkhttpRequestExecutor.kt
+++ b/src/main/java/uos/dev/restcli/executor/OkhttpRequestExecutor.kt
@@ -70,6 +70,7 @@ class OkhttpRequestExecutor(
     override fun execute(request: Request): Response {
         val client = okHttpClient.newBuilder().followRedirects(request.isFollowRedirects)
             .connectTimeout(requestTimeout, TimeUnit.MILLISECONDS)
+            .readTimeout(requestTimeout, TimeUnit.MILLISECONDS)
             .callTimeout(requestTimeout, TimeUnit.MILLISECONDS).build()
         val builder = OkhttpRequest.Builder()
         val requestTarget = obtainRequestTarget(request)

--- a/src/test/resources/requests/requests-with-failing-tests.http
+++ b/src/test/resources/requests/requests-with-failing-tests.http
@@ -42,6 +42,8 @@ client.test("Headers option exists", function() {
 ### timeout after 3s (this request took 4s)
 GET https://httpbin.org/delay/4
 
+### timeout after 3s (this request took 4s)
+HEAD https://httpbin.org/delay/4
 
 ### javascript error
 GET https://httpbin.org/get


### PR DESCRIPTION
We encountered, that "OkHttpClient" has multiple timeouts. A HEAD request needs a different timeout in comparison to a GET request. 

Please see this documentation for more details: https://www.baeldung.com/okhttp-timeouts#connect 
Quite confusing...

Please accept this PR, as it allows users to make HEAD requests which may take longer then 10 seconds.